### PR TITLE
fix: pin urllib3 version

### DIFF
--- a/preview_build/requirements.txt
+++ b/preview_build/requirements.txt
@@ -1,3 +1,4 @@
 Sphinx==4.4.0
 sphinx-autobuild==2021.3.14
+urllib3==1.26.6
 docs-italia-theme @ git+https://github.com/italia/docs-italia-theme.git@7bfccf507a7520b5fed5eda4b5c51c1f9d45ad88


### PR DESCRIPTION
The preview build fails because of
https://github.com/readthedocs/readthedocs.org/issues/10290, let's pin urllib3 to workaround that.